### PR TITLE
Add anyuid-based security context constraint for runAsUser UID.

### DIFF
--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       securityContext:
-        runAsUser: 1000060001
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       volumes:
       - name: portieris-certs
         secret:

--- a/helm/portieris/templates/securitycontextconstraint.yaml
+++ b/helm/portieris/templates/securitycontextconstraint.yaml
@@ -1,0 +1,43 @@
+{{ if .Capabilities.APIVersions.Has "clusterversions.config.openshift.io" }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: []
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID.
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "1"
+  name: anyuid-portieris
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: MustRunAs
+  uid: {{ .Values.securityContext.runAsUser }}
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:portieris:portieris
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{ end }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -17,6 +17,9 @@ service:
   port: 443
   targetPort: 8000
 
+securityContext:
+  runAsUser: 1000060001
+
 # If not running on IBM Cloud Container Service set to false
 IBMContainerService: true
 


### PR DESCRIPTION
Add anyuid-based security context constraint for portieris service account.  This enhancement adds an OpenShift security context constraint, specifying the explicit UID in `runAsUser/MustRunAs` section.  Minor refactoring moves the desired UID value, currently `1000060001`, into values.yaml in order to keep things DRY.