### PR TITLE
Add cluster image policy for quay.io images

### DIFF
--- a/helm/portieris/templates/default/policies.yaml
+++ b/helm/portieris/templates/default/policies.yaml
@@ -71,4 +71,6 @@ spec:
       policy:
         trust:
           enabled: true
+    - name: "quay.io/openshift-release-dev/*"
+      policy:
 {{ end }}


### PR DESCRIPTION
Add cluster image policy for quay.io/openshift-release-dev/* images

Closes https://github.com/IBM/portieris/issues/131